### PR TITLE
Add Enumerated::jsonSerializeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage/
 vendor/
 phpunit.xml
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -125,3 +125,47 @@ echo $message; // Process completed
 ```
 
 each value only exists once, which is why the strict comparison also works.
+
+## features
+
+### json serializeable
+
+The trait already implements the method `jsonSerialize` from the interface `\JsonSerializable`. This means that you can
+add the `\JsonSerializable` to your own enum and with this `\json_encode` will automatically serialize the value in the
+right manner. Beware that `\json_decode` won't automatically decode it back into the enum. This job must be tackled
+manually. See this example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum\Example;
+
+use JsonSerializable;
+use Patchlevel\Enum\Enumerated;
+use function json_encode;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @psalm-immutable
+ * @method static self up()
+ * @method static self down()
+ * @method static self left()
+ * @method static self right()
+ */
+final class Direction implements JsonSerializable
+{
+    use Enumerated;
+
+    private const UP = 'up';
+    private const DOWN = 'down';
+    private const LEFT = 'left';
+    private const RIGHT = 'right';
+}
+
+$directionUp = Direction::up();
+
+// this will result int the string "up"
+$encodedDirectionUp = json_encode($directionUp, JSON_THROW_ON_ERROR);
+```

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "php": "^7.4"
   },
   "require-dev": {
+    "ext-json": "^7.4",
     "phpstan/phpstan": "^0.12.54",
     "phpunit/phpunit": "^9.4.3",
     "vimeo/psalm": "^4.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76170124197028fa5e03c8f6e56a3107",
+    "content-hash": "aed72479243e86e7c63da4aaddbb1259",
     "packages": [],
     "packages-dev": [
         {
@@ -3699,6 +3699,8 @@
     "platform": {
         "php": "^7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-json": "^7.4"
+    },
     "plugin-api-version": "2.0.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,6 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
-        <exclude>
-            <directory>src/Infrastructure/Migration</directory>
-            <file>src/Infrastructure/ExceptionCollector.php</file>
-            <file>src/Infrastructure/Kernel.php</file>
-        </exclude>
         <report>
             <html outputDirectory="./coverage"/>
             <text outputFile="php://stdout"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,11 +5,22 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory>src/Infrastructure/Migration</directory>
+            <file>src/Infrastructure/ExceptionCollector.php</file>
+            <file>src/Infrastructure/Kernel.php</file>
+        </exclude>
+        <report>
+            <html outputDirectory="./coverage"/>
+            <text outputFile="php://stdout"/>
+        </report>
+    </coverage>
+
     <php>
         <ini name="error_reporting" value="E_ALL"/>
     </php>

--- a/src/Enumerated.php
+++ b/src/Enumerated.php
@@ -39,11 +39,49 @@ trait Enumerated
      */
     public static function values(): array
     {
-        if (count(self::$values) === 0) {
-            self::init();
-        }
+        self::init();
 
         return array_values(self::$values);
+    }
+
+    /**
+     * @throws EnumException
+     */
+    public static function fromString(string $value): self
+    {
+        self::init();
+
+        if (array_key_exists($value, self::$values) === false) {
+            throw new EnumException(sprintf('invalid value "%s"', $value));
+        }
+
+        return self::$values[$value];
+    }
+
+    /**
+     * @psalm-assert-if-true self::* $value
+     */
+    public static function isValid(string $value): bool
+    {
+        self::init();
+
+        return array_key_exists($value, self::$values);
+    }
+
+    /**
+     * @psalm-assert self::* $name
+     *
+     * @throws BadMethodCallException
+     */
+    public static function __callStatic(string $name, array $arguments): self
+    {
+        self::init();
+
+        if (array_key_exists($name, self::$values) === false) {
+            throw new BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
+        }
+
+        return self::$values[$name];
     }
 
     public function equals(self $enum): bool
@@ -60,31 +98,11 @@ trait Enumerated
     }
 
     /**
-     * @throws EnumException
+     * @psalm-return self::*
      */
-    public static function fromString(string $value): self
+    public function jsonSerialize(): string
     {
-        if (!self::$values) {
-            self::init();
-        }
-
-        if (array_key_exists($value, self::$values) === false) {
-            throw new EnumException(sprintf('invalid value "%s"', $value));
-        }
-
-        return self::$values[$value];
-    }
-
-    /**
-     * @psalm-assert-if-true self::* $value
-     */
-    public static function isValid(string $value): bool
-    {
-        if (!self::$values) {
-            self::init();
-        }
-
-        return array_key_exists($value, self::$values);
+        return $this->toString();
     }
 
     /**
@@ -92,15 +110,17 @@ trait Enumerated
      */
     private static function get(string $value): self
     {
-        if (!self::$values) {
-            self::init();
-        }
+        self::init();
 
         return self::$values[$value];
     }
 
     private static function init(): void
     {
+        if (count(self::$values) > 0) {
+            return;
+        }
+
         $constants = (new ReflectionClass(static::class))->getReflectionConstants();
 
         foreach ($constants as $constantReflection) {
@@ -116,24 +136,5 @@ trait Enumerated
 
             self::$values[$constantValue] = new static($constantValue);
         }
-    }
-
-    /**
-     * @psalm-assert self::* $name
-     *
-     * @return static
-     * @throws BadMethodCallException
-     */
-    public static function __callStatic(string $name, array $arguments)
-    {
-        if (!self::$values) {
-            self::init();
-        }
-
-        if (array_key_exists($name, self::$values) === false) {
-            throw new BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
-        }
-
-        return self::$values[$name];
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -118,7 +118,7 @@ class EnumTest extends TestCase
                 Status::created(),
                 Status::pending(),
                 Status::running(),
-                Status::completed()
+                Status::completed(),
             ],
             $values
         );
@@ -129,5 +129,24 @@ class EnumTest extends TestCase
         $this->expectException(EnumException::class);
 
         BrokenEnum::created();
+    }
+
+    public function testSerializeAble(): void
+    {
+        $completed = Status::completed();
+        $unserialized = unserialize(serialize($completed));
+
+        self::assertEquals($completed, $unserialized);
+        self::assertNotSame($completed, $unserialized);
+    }
+
+    public function testJsonSerializeAble(): void
+    {
+        $completed = Status::completed();
+
+        $jsonEncoded = json_encode($completed, JSON_THROW_ON_ERROR);
+        $jsonDecoded = json_decode($jsonEncoded, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame($completed, Status::fromString($jsonDecoded));
     }
 }

--- a/tests/Enums/Status.php
+++ b/tests/Enums/Status.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Tests\Enums;
 
+use JsonSerializable;
 use Patchlevel\Enum\Enumerated;
 
-final class Status
+final class Status implements JsonSerializable
 {
     use Enumerated;
 


### PR DESCRIPTION
This adds the ability to `json_encode` the Enum.
Since this is a trait  the user must add the interface himself to the enum.

This patch still need to update the examples. First i would like to know your opinion on this :)