### PR TITLE
remove equals method

### DIFF
--- a/src/Enumerated.php
+++ b/src/Enumerated.php
@@ -69,11 +69,6 @@ trait Enumerated
         return array_key_exists($value, self::$values);
     }
 
-    public function equals(self $enum): bool
-    {
-        return $this === $enum;
-    }
-
     /**
      * @psalm-return self::*
      */

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -70,22 +70,6 @@ class EnumTest extends TestCase
         self::assertFalse(Status::isValid('foo'));
     }
 
-    public function testEquals(): void
-    {
-        $a = Status::created();
-        $b = Status::created();
-
-        self::assertTrue($a->equals($b));
-    }
-
-    public function testNotEquals(): void
-    {
-        $a = Status::created();
-        $b = Status::completed();
-
-        self::assertFalse($a->equals($b));
-    }
-
     public function testValues(): void
     {
         $values = Status::values();


### PR DESCRIPTION
the equals method is not needed, a strict comparison is sufficient here. The equals method confused only.

```php
$a = Status::panding();

if ($a->equals(Status::completed())) {
  // ...
}
```

vs.

```php
$a = Status::panding();

if ($a === Status::completed()) {
  // ...
}
```