### PR TITLE
Explicit Exceptions

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,6 +13,6 @@
   "mutators": {
     "@default": true
   },
-  "minMsi": 86,
-  "minCoveredMsi": 86
+  "minMsi": 89,
+  "minCoveredMsi": 89
 }

--- a/src/BadMethodCall.php
+++ b/src/BadMethodCall.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum;
+
+use function array_map;
+use function implode;
+use function sprintf;
+
+final class BadMethodCall extends EnumException
+{
+    /**
+     * @param array<string> $values
+     */
+    public function __construct(string $value, array $values)
+    {
+        parent::__construct(sprintf(
+            'Invalid method [::%s()] called. Valid values are: %s',
+            $value,
+            implode(
+                ', ',
+                array_map(
+                    static fn (string $value) => sprintf('::%s()', $value),
+                    $values
+                )
+            )
+        ));
+    }
+}

--- a/src/BadMethodCall.php
+++ b/src/BadMethodCall.php
@@ -16,7 +16,7 @@ final class BadMethodCall extends EnumException
     public function __construct(string $value, array $values)
     {
         parent::__construct(sprintf(
-            'Invalid method [::%s()] called. Valid values are: %s',
+            'Invalid method [::%s()] called. Valid methods are: %s',
             $value,
             implode(
                 ', ',

--- a/src/DuplicateValue.php
+++ b/src/DuplicateValue.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum;
+
+use function sprintf;
+
+final class DuplicateValue extends EnumException
+{
+    public function __construct(string $value, string $enum)
+    {
+        parent::__construct(sprintf('Duplicated value [%s] for enum [%s] found', $value, $enum));
+    }
+}

--- a/src/EnumException.php
+++ b/src/EnumException.php
@@ -6,6 +6,6 @@ namespace Patchlevel\Enum;
 
 use RuntimeException;
 
-final class EnumException extends RuntimeException
+abstract class EnumException extends RuntimeException
 {
 }

--- a/src/EnumException.php
+++ b/src/EnumException.php
@@ -6,6 +6,9 @@ namespace Patchlevel\Enum;
 
 use RuntimeException;
 
+/**
+ * @internal
+ */
 abstract class EnumException extends RuntimeException
 {
 }

--- a/src/InvalidValue.php
+++ b/src/InvalidValue.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum;
+
+use function implode;
+use function sprintf;
+
+final class InvalidValue extends EnumException
+{
+    /**
+     * @param array<string> $values
+     */
+    public function __construct(string $value, array $values)
+    {
+        parent::__construct(sprintf(
+            'Invalid value [%s] found. Valid values are: %s',
+            $value,
+            implode(', ', $values)
+        ));
+    }
+}

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Tests;
 
-use BadMethodCallException;
-use Patchlevel\Enum\EnumException;
+use Patchlevel\Enum\BadMethodCall;
+use Patchlevel\Enum\DuplicateValue;
+use Patchlevel\Enum\InvalidValue;
 use Patchlevel\Enum\Tests\Enums\BrokenEnum;
 use Patchlevel\Enum\Tests\Enums\Status;
 use Patchlevel\Enum\Tests\Enums\Type;
@@ -39,14 +40,14 @@ class EnumTest extends TestCase
 
     public function testCreateMagicStaticCallInvalid(): void
     {
-        $this->expectException(BadMethodCallException::class);
+        $this->expectException(BadMethodCall::class);
 
         Type::foo();
     }
 
     public function testCreateFromStringInvalid(): void
     {
-        $this->expectException(EnumException::class);
+        $this->expectException(InvalidValue::class);
 
         Status::fromString('foo');
     }
@@ -126,7 +127,7 @@ class EnumTest extends TestCase
 
     public function testDuplicatedValue(): void
     {
-        $this->expectException(EnumException::class);
+        $this->expectException(DuplicateValue::class);
 
         BrokenEnum::created();
     }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -41,6 +41,7 @@ class EnumTest extends TestCase
     public function testCreateMagicStaticCallInvalid(): void
     {
         $this->expectException(BadMethodCall::class);
+        $this->expectExceptionMessage('Invalid method [::foo()] called. Valid methods are: ::intern(), ::extern()');
 
         Type::foo();
     }
@@ -48,6 +49,7 @@ class EnumTest extends TestCase
     public function testCreateFromStringInvalid(): void
     {
         $this->expectException(InvalidValue::class);
+        $this->expectExceptionMessage('Invalid value [foo] found. Valid values are: created, pending, running, completed');
 
         Status::fromString('foo');
     }
@@ -128,6 +130,7 @@ class EnumTest extends TestCase
     public function testDuplicatedValue(): void
     {
         $this->expectException(DuplicateValue::class);
+        $this->expectExceptionMessage('Duplicated value [created] for enum [Patchlevel\Enum\Tests\Enums\BrokenEnum] found');
 
         BrokenEnum::created();
     }


### PR DESCRIPTION
I added per UseCase Exception classes and made the general EnumException therefore abstract.
Also moved BadMethodCall into this hierarchy so that it is also catchable via
```php
try {
    // do something
} catch (EnumException $exception) {
    // enum stuff blew up
}
``` 