### PR TITLE
alternative implementation (take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ phpstan:                                                                        
 psalm:                                                                          ## run psalm static code analyser
 	vendor/bin/psalm
 
+infection:                                                                      ## run infection
+	vendor/bin/infection
+
 .PHONY: phpunit
 phpunit:                                                                        ## run phpunit tests
 	vendor/bin/phpunit --testdox --colors=always -v $(OPTIONS)
@@ -28,4 +31,4 @@ static: php-cs-fix phpstan psalm                                                
 test: phpunit                                                                   ## run tests
 
 .PHONY: dev
-dev: static test                                                                ## run dev tools
+dev: static test infection                                                      ## run dev tools

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Example;
 
-use Patchlevel\Enum\Enumerated;
+use Patchlevel\Enum\Enum;
 
 /**
  * @psalm-immutable
  */
-final class Status
+final class Status extends Enum
 {
-    use Enumerated;
-
     private const CREATED = 'created';
     private const PENDING = 'pending';
     private const RUNNING = 'running';
@@ -66,7 +64,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Example;
 
-use Patchlevel\Enum\ExtendedEnumerated;
+use Patchlevel\Enum\ExtendedEnum;
 
 /**
  * @psalm-immutable
@@ -75,10 +73,8 @@ use Patchlevel\Enum\ExtendedEnumerated;
  * @method static self running()
  * @method static self completed()
  */
-final class Status
+final class Status extends ExtendedEnum
 {
-    use ExtendedEnumerated;
-
     private const CREATED = 'created';
     private const PENDING = 'pending';
     private const RUNNING = 'running';
@@ -144,8 +140,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Example;
 
-use JsonSerializable;
-use Patchlevel\Enum\ExtendedEnumerated;
+use Patchlevel\Enum\ExtendedEnum;
 use function json_encode;
 use const JSON_THROW_ON_ERROR;
 
@@ -156,10 +151,8 @@ use const JSON_THROW_ON_ERROR;
  * @method static self left()
  * @method static self right()
  */
-final class Direction implements JsonSerializable
+final class Direction extends ExtendedEnum
 {
-    use ExtendedEnumerated;
-
     private const UP = 'up';
     private const DOWN = 'down';
     private const LEFT = 'left';

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,15 @@
         }
     ],
     "require": {
-        "php": "^7.4"
+        "php": "^7.4",
+        "ext-json": "^7.4"
     },
     "require-dev": {
-        "ext-json": "^7.4",
         "friendsofphp/php-cs-fixer": "^2.16.7",
         "infection/infection": "^0.20.1",
         "phpstan/phpstan": "^0.12.56",
         "phpunit/phpunit": "^9.4.3",
+        "symfony/var-dumper": "^5.1",
         "vimeo/psalm": "^4.1.1"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a65d49466d515e60a9219fba8d7294ca",
+    "content-hash": "1b8a6a28b8be3d659cea16fc984cd543",
     "packages": [],
     "packages-dev": [
         {
@@ -5016,6 +5016,94 @@
             "time": "2020-10-24T12:01:57+00:00"
         },
         {
+            "name": "symfony/var-dumper",
+            "version": "v5.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-27T10:11:13+00:00"
+        },
+        {
             "name": "thecodingmachine/safe",
             "version": "v1.3.3",
             "source": {
@@ -5419,10 +5507,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4"
-    },
-    "platform-dev": {
+        "php": "^7.4",
         "ext-json": "^7.4"
     },
+    "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/example/Direction.php
+++ b/example/Direction.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\Enum\Example;
 
 use const JSON_THROW_ON_ERROR;
-use JsonSerializable;
-use Patchlevel\Enum\ExtendedEnumerated;
+use Patchlevel\Enum\ExtendedEnum;
 use function json_encode;
 
 /**
@@ -16,10 +15,8 @@ use function json_encode;
  * @method static self left()
  * @method static self right()
  */
-final class Direction implements JsonSerializable
+final class Direction extends ExtendedEnum
 {
-    use ExtendedEnumerated;
-
     private const UP = 'up';
     private const DOWN = 'down';
     private const LEFT = 'left';

--- a/example/Status.php
+++ b/example/Status.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Example;
 
-use Patchlevel\Enum\Enumerated;
+use Patchlevel\Enum\Enum;
 
 /**
  * @psalm-immutable
  */
-final class Status
+final class Status extends Enum
 {
-    use Enumerated;
-
     private const CREATED = 'created';
     private const PENDING = 'pending';
     private const RUNNING = 'running';

--- a/example/Type.php
+++ b/example/Type.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Example;
 
-use Patchlevel\Enum\ExtendedEnumerated;
+use Patchlevel\Enum\ExtendedEnum;
 
 /**
  * @psalm-immutable
  * @method static self extern()
  * @method static self intern()
  */
-final class Type
+final class Type extends ExtendedEnum
 {
-    use ExtendedEnumerated;
-
     private const INTERN = 'intern';
     private const EXTERN = 'extern';
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,6 +13,6 @@
   "mutators": {
     "@default": true
   },
-  "minMsi": 89,
-  "minCoveredMsi": 89
+  "minMsi": 90,
+  "minCoveredMsi": 90
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,6 +13,6 @@
   "mutators": {
     "@default": true
   },
-  "minMsi": 86,
-  "minCoveredMsi": 86
+  "minMsi": 89,
+  "minCoveredMsi": 89
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,6 +13,6 @@
   "mutators": {
     "@default": true
   },
-  "minMsi": 90,
-  "minCoveredMsi": 90
+  "minMsi": 93,
+  "minCoveredMsi": 93
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -98,7 +98,7 @@ abstract class Enum
             $constantValue = $constantReflection->getValue();
 
             if (!is_string($constantValue)) {
-                throw new InvalidValueType($constantReflection->getName());
+                throw new InvalidValueType(static::class, $constantReflection->getName());
             }
 
             if (array_key_exists($constantValue, self::$values[static::class])) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -18,6 +18,7 @@ use function array_values;
 abstract class Enum
 {
     /**
+     * @internal
      * @psalm-var array<string, array<string, static>>
      */
     protected static array $values = [];
@@ -87,6 +88,7 @@ abstract class Enum
     }
 
     /**
+     * @internal
      * @throws DuplicateValue
      */
     protected static function init(): void

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -21,7 +21,7 @@ abstract class Enum
      */
     private static array $values = [];
 
-    protected string $value;
+    private string $value;
 
     final private function __construct(string $value)
     {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -9,7 +9,6 @@ use Patchlevel\Enum\Exception\InvalidValue;
 use Patchlevel\Enum\Exception\InvalidValueType;
 use ReflectionClass;
 use function array_key_exists;
-use function array_map;
 use function array_values;
 
 /**
@@ -50,10 +49,7 @@ abstract class Enum
         if (array_key_exists($value, self::$values[static::class]) === false) {
             throw new InvalidValue(
                 $value,
-                array_map(
-                    static fn (self $value) => $value->toString(),
-                    self::$values[static::class]
-                )
+                array_keys(self::$values[static::class])
             );
         }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -17,10 +17,9 @@ use function array_values;
 abstract class Enum
 {
     /**
-     * @internal
      * @psalm-var array<string, array<string, static>>
      */
-    protected static array $values = [];
+    private static array $values = [];
 
     protected string $value;
 
@@ -30,7 +29,7 @@ abstract class Enum
     }
 
     /**
-     * @return array<int, self>
+     * @return array<int, static>
      */
     public static function values(): array
     {
@@ -40,7 +39,18 @@ abstract class Enum
     }
 
     /**
+     * @return array<int, string>
+     */
+    public static function keys(): array
+    {
+        self::init();
+
+        return array_keys(self::$values[static::class]);
+    }
+
+    /**
      * @throws InvalidValue
+     * @return static
      */
     public static function fromString(string $value): self
     {
@@ -84,10 +94,9 @@ abstract class Enum
     }
 
     /**
-     * @internal
      * @throws DuplicateValue
      */
-    protected static function init(): void
+    private static function init(): void
     {
         if (array_key_exists(static::class, self::$values)) {
             return;

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -66,6 +66,11 @@ abstract class Enum
         return array_key_exists($value, self::$values[static::class]);
     }
 
+    public function equals(self $enum): bool
+    {
+        return $this === $enum;
+    }
+
     public function toString(): string
     {
         return $this->value;

--- a/src/Exception/InvalidValueType.php
+++ b/src/Exception/InvalidValueType.php
@@ -8,10 +8,11 @@ use function sprintf;
 
 final class InvalidValueType extends EnumException
 {
-    public function __construct(string $constant)
+    public function __construct(string $class, string $constant)
     {
         parent::__construct(sprintf(
-            'Invalid value in ::%s. value need to be a string.',
+            'Invalid value in %s::%s. value need to be a string.',
+            $class,
             $constant
         ));
     }

--- a/src/Exception/InvalidValueType.php
+++ b/src/Exception/InvalidValueType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum\Exception;
+
+use function sprintf;
+
+final class InvalidValueType extends EnumException
+{
+    public function __construct(string $constant)
+    {
+        parent::__construct(sprintf(
+            'Invalid value in ::%s. value need to be a string.',
+            $constant
+        ));
+    }
+}

--- a/src/ExtendedEnum.php
+++ b/src/ExtendedEnum.php
@@ -31,10 +31,7 @@ abstract class ExtendedEnum extends Enum implements JsonSerializable
         if (array_key_exists($name, self::$values[static::class]) === false) {
             throw new BadMethodCall(
                 $name,
-                array_map(
-                    static fn (self $value) => $value->toString(),
-                    self::$values[static::class]
-                )
+                array_keys(self::$values[static::class])
             );
         }
 

--- a/src/ExtendedEnum.php
+++ b/src/ExtendedEnum.php
@@ -6,7 +6,7 @@ namespace Patchlevel\Enum;
 
 use JsonSerializable;
 use Patchlevel\Enum\Exception\BadMethodCall;
-use function array_key_exists;
+use Patchlevel\Enum\Exception\InvalidValue;
 
 /**
  * @psalm-immutable
@@ -26,16 +26,14 @@ abstract class ExtendedEnum extends Enum implements JsonSerializable
      */
     public static function __callStatic(string $name, array $arguments): self
     {
-        self::init();
-
-        if (array_key_exists($name, self::$values[static::class]) === false) {
+        try {
+            return static::fromString($name);
+        } catch (InvalidValue $e) {
             throw new BadMethodCall(
                 $name,
-                array_keys(self::$values[static::class])
+                static::keys()
             );
         }
-
-        return self::$values[static::class][$name];
     }
 
     public function __toString(): string

--- a/src/ExtendedEnum.php
+++ b/src/ExtendedEnum.php
@@ -4,27 +4,23 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum;
 
+use JsonSerializable;
 use Patchlevel\Enum\Exception\BadMethodCall;
 use function array_key_exists;
 
 /**
  * @psalm-immutable
  */
-trait ExtendedEnumerated
+abstract class ExtendedEnum extends Enum implements JsonSerializable
 {
-    use Enumerated;
-
-    /**
-     * @psalm-return self::*
-     */
     public function jsonSerialize(): string
     {
         return $this->toString();
     }
 
     /**
-     * @psalm-assert self::* $name
      * @param array<mixed> $arguments
+     * @return static
      *
      * @throws BadMethodCall
      */
@@ -32,16 +28,19 @@ trait ExtendedEnumerated
     {
         self::init();
 
-        if (array_key_exists($name, self::$values) === false) {
-            throw new BadMethodCall($name, array_map(static fn (self $value) => $value->toString(), self::$values));
+        if (array_key_exists($name, self::$values[static::class]) === false) {
+            throw new BadMethodCall(
+                $name,
+                array_map(
+                    static fn (self $value) => $value->toString(),
+                    self::$values[static::class]
+                )
+            );
         }
 
-        return self::$values[$name];
+        return self::$values[static::class][$name];
     }
 
-    /**
-     * @psalm-return self::*
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -72,6 +72,22 @@ class EnumTest extends TestCase
         self::assertFalse(Status::isValid('foo'));
     }
 
+    public function testEquals(): void
+    {
+        $a = Status::created();
+        $b = Status::created();
+
+        self::assertTrue($a->equals($b));
+    }
+
+    public function testNotEquals(): void
+    {
+        $a = Status::created();
+        $b = Status::completed();
+
+        self::assertFalse($a->equals($b));
+    }
+
     public function testValues(): void
     {
         $values = Status::values();

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -6,7 +6,9 @@ namespace Patchlevel\Enum\Tests;
 
 use Patchlevel\Enum\Exception\DuplicateValue;
 use Patchlevel\Enum\Exception\InvalidValue;
+use Patchlevel\Enum\Exception\InvalidValueType;
 use Patchlevel\Enum\Tests\Enums\BrokenEnum;
+use Patchlevel\Enum\Tests\Enums\BrokenWithIntegerEnum;
 use Patchlevel\Enum\Tests\Enums\Status;
 use PHPUnit\Framework\TestCase;
 
@@ -91,6 +93,14 @@ class EnumTest extends TestCase
         $this->expectExceptionMessage('Duplicated value [created] for enum [Patchlevel\Enum\Tests\Enums\BrokenEnum] found');
 
         BrokenEnum::created();
+    }
+
+    public function testInvalidType(): void
+    {
+        $this->expectException(InvalidValueType::class);
+        $this->expectExceptionMessage('Invalid value in Patchlevel\Enum\Tests\Enums\BrokenWithIntegerEnum::CREATED. value need to be a string.');
+
+        BrokenWithIntegerEnum::isValid('foo');
     }
 
     public function testSerializable(): void

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -103,6 +103,21 @@ class EnumTest extends TestCase
         );
     }
 
+    public function testKeys(): void
+    {
+        $values = Status::keys();
+
+        self::assertEquals(
+            [
+                'created',
+                'pending',
+                'running',
+                'completed',
+            ],
+            $values
+        );
+    }
+
     public function testDuplicatedValue(): void
     {
         $this->expectException(DuplicateValue::class);

--- a/tests/Enums/BrokenEnum.php
+++ b/tests/Enums/BrokenEnum.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Tests\Enums;
 
-use Patchlevel\Enum\Enumerated;
+use Patchlevel\Enum\Enum;
 
-final class BrokenEnum
+final class BrokenEnum extends Enum
 {
-    use Enumerated;
-
     private const CREATED = 'created';
     private const PENDING = 'created';
 

--- a/tests/Enums/BrokenWithIntegerEnum.php
+++ b/tests/Enums/BrokenWithIntegerEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Enum\Tests\Enums;
+
+use Patchlevel\Enum\Enum;
+
+final class BrokenWithIntegerEnum extends Enum
+{
+    private const CREATED = 1;
+    private const PENDING = 2;
+
+    public static function created(): self
+    {
+        return self::get(self::CREATED);
+    }
+
+    public static function pending(): self
+    {
+        return self::get(self::PENDING);
+    }
+}

--- a/tests/Enums/Status.php
+++ b/tests/Enums/Status.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Tests\Enums;
 
-use Patchlevel\Enum\Enumerated;
+use Patchlevel\Enum\Enum;
 
-final class Status
+final class Status extends Enum
 {
-    use Enumerated;
-
     private const CREATED = 'created';
     private const PENDING = 'pending';
     private const RUNNING = 'running';

--- a/tests/Enums/Type.php
+++ b/tests/Enums/Type.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace Patchlevel\Enum\Tests\Enums;
 
-use JsonSerializable;
-use Patchlevel\Enum\ExtendedEnumerated;
+use Patchlevel\Enum\ExtendedEnum;
 
 /**
  * @psalm-immutable
  * @method static self extern()
  * @method static self intern()
  */
-final class Type implements JsonSerializable
+final class Type extends ExtendedEnum
 {
-    use ExtendedEnumerated;
-
     private const INTERN = 'intern';
     private const EXTERN = 'extern';
 }


### PR DESCRIPTION
I had to remove the pslam `self::*` check. As long as `static::*` or `T::*` (with generics) are not supported, we cannot prevent this Psalm feature. 
My opinion is that Psalm should not prevent our aspired architecture, but complement it. 
As soon as psalm can do this we can add it again.

and this replace #8 (Enum Interface)